### PR TITLE
Issue #1: Replace residual variable_get() call.

### DIFF
--- a/webform_autocomplete.module
+++ b/webform_autocomplete.module
@@ -63,8 +63,7 @@ function webform_autocomplete_access($node, $cid) {
   if (!empty($node->webform['components'][$cid]['private'])) {
     return FALSE;
   }
-  // TODO This variable was probably removed in Backdrop without replacement.
-  if (variable_get('webform_submission_access_control', 1)) {
+  if (config_get('webform.settings', 'webform_submission_access_control')) {
     $allowed_roles = array();
     foreach ($node->webform['roles'] as $rid) {
       $allowed_roles[$rid] = isset($user->roles[$rid]) ? TRUE : FALSE;


### PR DESCRIPTION
Fixes https://github.com/backdrop-contrib/webform_autocomplete/issues/1.